### PR TITLE
History improvements

### DIFF
--- a/examples/history.rs
+++ b/examples/history.rs
@@ -7,12 +7,10 @@ fn main() {
     println!("Use the Up/Down arrows to scroll through history");
     println!();
 
-    let mut history = MyHistory::default();
-
     loop {
         if let Ok(cmd) = Input::<String>::with_theme(&ColorfulTheme::default())
             .with_prompt("dialoguer")
-            .history_with(&mut history)
+            .history_with(&mut std::collections::VecDeque::new())
             .interact_text()
         {
             if cmd == "exit" {

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,4 +1,4 @@
-use std::collections::VecDeque;
+use crate::prompts::input::HistoryContainer;
 
 /// Trait for history handling.
 pub trait History {
@@ -16,12 +16,18 @@ pub trait History {
     fn write(&mut self, val: String);
 }
 
-impl History for VecDeque<String> {
+impl History for HistoryContainer<'_> {
     fn read(&self, pos: usize) -> Option<String> {
-        self.get(pos).cloned()
+        match self {
+            HistoryContainer::Referenced(h) => h.read(pos),
+            HistoryContainer::Infinite(vd) => vd.get(pos).cloned(),
+        }
     }
 
     fn write(&mut self, val: String) {
-        self.push_front(val)
+        match self {
+            HistoryContainer::Referenced(h) => h.write(val),
+            HistoryContainer::Infinite(vd) => vd.push_front(val),
+        }
     }
 }

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,5 +1,7 @@
+use std::collections::VecDeque;
+
 /// Trait for history handling.
-pub trait History<T> {
+pub trait History {
     /// This is called with the current position that should
     /// be read from history. The `pos` represents the number
     /// of times the `Up`/`Down` arrow key has been pressed.
@@ -11,5 +13,15 @@ pub trait History<T> {
     /// This is called with the next value you should store
     /// in history at the first location. Normally history
     /// is implemented as a FIFO queue.
-    fn write(&mut self, val: &T);
+    fn write(&mut self, val: String);
+}
+
+impl History for VecDeque<String> {
+    fn read(&self, pos: usize) -> Option<String> {
+        self.get(pos).cloned()
+    }
+
+    fn write(&mut self, val: String) {
+        self.push_front(val)
+    }
 }

--- a/src/prompts/input.rs
+++ b/src/prompts/input.rs
@@ -191,15 +191,15 @@ impl<'a, T> Input<'a, T> {
     ///     }
     /// }
     ///
-    /// impl<T: ToString> History<T> for MyHistory {
+    /// impl History for MyHistory {
     ///     fn read(&self, pos: usize) -> Option<String> {
     ///         self.history.get(pos).cloned()
     ///     }
     ///
-    ///     fn write(&mut self, val: &T)
+    ///     fn write(&mut self, val: String)
     ///     where
     ///     {
-    ///         self.history.push_front(val.to_string());
+    ///         self.history.push_front(val);
     ///     }
     /// }
     ///


### PR DESCRIPTION
Add a handy `history_infinite()` method for `Input`s with validation.
`history_infinite()` uses `VecDeque<String>`.

The `History` trait is simplified to not require a generic parameter. 

`HistoryContainer` for commonly used algorithms for history:
- [ ] Add `HistoryContainer::Dedup` variant